### PR TITLE
added test and updated docs to indicate that some initial progress output will still be output if you set SetOption('no_progress')

### DIFF
--- a/src/CHANGES.txt
+++ b/src/CHANGES.txt
@@ -7,7 +7,7 @@
 RELEASE  VERSION/DATE TO BE FILLED IN LATER
 
   From Daniel Moody:
-    - Add no_progress option as a set-able option
+    - Add no_progress (-Q) option as a set-able option
 
   From Mathew Robinson:
 

--- a/src/engine/SCons/Script/Main.xml
+++ b/src/engine/SCons/Script/Main.xml
@@ -794,6 +794,10 @@ which corresponds to --silent.
 <para>
 which corresponds to -Q.
 </para>
+<para>
+    Note: The initial progress output will still be output as this is done before the SConstruct/SConscript which contains the SetOption is processed
+    <literal>scons: Reading SConscript files ...</literal>
+</para>
 </listitem>
 </varlistentry>
 <varlistentry>

--- a/src/engine/SCons/Script/SConsOptions.py
+++ b/src/engine/SCons/Script/SConsOptions.py
@@ -198,6 +198,9 @@ class SConsValues(optparse.Values):
                 value = [value]
             value = self.__SConscript_settings__.get(name, []) + value
             SCons.Warnings.process_warn_strings(value)
+        elif name == 'no_progress':
+            SCons.Script.Main.progress_display.set_mode(False)
+
 
         self.__SConscript_settings__[name] = value
 

--- a/test/option--Q.py
+++ b/test/option--Q.py
@@ -31,6 +31,8 @@ import TestSCons
 _python_ = TestSCons._python_
 
 test = TestSCons.TestSCons()
+test.verbose_set(1)
+
 
 test.write('build.py', r"""
 import sys
@@ -40,6 +42,15 @@ file.close()
 """)
 
 test.write('SConstruct', """
+
+AddOption('--use_SetOption', action='store_true', dest='setoption', default=False)
+
+use_setoption=GetOption('setoption')
+
+if use_setoption:
+    # SetOption('no_progress', False)
+    pass
+    
 MyBuild = Builder(action = r'%(_python_)s build.py $TARGET')
 env = Environment(BUILDERS = { 'MyBuild' : MyBuild })
 env.MyBuild(target = 'f1.out', source = 'f1.in')
@@ -63,6 +74,19 @@ Removed f2.out
 """)
 test.fail_test(os.path.exists(test.workpath('f1.out')))
 test.fail_test(os.path.exists(test.workpath('f2.out')))
+
+
+# When set via a SetOption, it will happen after the initial output of
+# scons: Reading SConscript files ...
+# but remaining status/progress output will not be output
+test.run(arguments = '--use_SetOption f1.out f2.out', stdout = """\
+scons: Reading SConscript files ...
+%(_python_)s build.py f1.out
+%(_python_)s build.py f2.out
+""" % locals())
+test.fail_test(not os.path.exists(test.workpath('f1.out')))
+test.fail_test(not os.path.exists(test.workpath('f2.out')))
+
 
 test.pass_test()
 


### PR DESCRIPTION
added test and updated docs to indicate that some initial progress output will still be output if you set SetOption('no_progress')

## Contributor Checklist:

* [x] I have created a new test or updated the unit tests to cover the new/changed functionality.
* [x] I have updated `master/src/CHANGES.txt` directory (and read the `README.txt` in that directory)
* [x] I have updated the appropriate documentation
